### PR TITLE
Whitelist necessary files for package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
  "version": "1.1.1",
  "description": "Native libshout bindings for node.",
  "main": "src/index.js",
+ "files": [
+  "/src"
+ ],
  "scripts": {
   "test": "echo \"Error: no test specified\" && exit 1"
  },


### PR DESCRIPTION
By default, `npm publish` will pack all files which is not listed on `.gitignore`, which includes almost a megabyte of music files and documentation file.

This PR add `files` section to the `package.json` file, which limits files to be published.

By running `npm pack`, you can check the list of files to be packed and published.